### PR TITLE
WP NFT storage without name

### DIFF
--- a/wordpress/kredeum-nfts/admin/ipfs/nft-storage.php
+++ b/wordpress/kredeum-nfts/admin/ipfs/nft-storage.php
@@ -8,19 +8,19 @@
 namespace KredeumNFTs\Ipfs;
 
 /**
- * IPFS add and pin file with NFT Storage
+ * IPFS add and pin file inside directory with NFT Storage
  *
  * @param string $attachment_id Id attachment file.
- * @param int    $version CID version : 1 (or 0).
  *
  * @return string CID hash
  */
-function nft_storage_add_and_pin( $attachment_id, $version = IPFS_CID_VERSION ) {
+function nft_storage_add_and_pin_dir( $attachment_id ) {
 	$api = new \RestClient( array( 'base_url' => 'https://api.nft.storage' ) );
 
-	$boundary = md5( time() );
 	$file     = file_get_contents( get_attached_file( $attachment_id ) );
 	$filename = get_attached_file_meta( $attachment_id )->filename;
+
+	$boundary = md5( time() );
 	$parts    = array(
 		array(
 			'type'    => 'file',
@@ -28,14 +28,14 @@ function nft_storage_add_and_pin( $attachment_id, $version = IPFS_CID_VERSION ) 
 			'content' => $file,
 		),
 	);
-
-	$buffer  = multipart( $parts, $boundary );
-	$headers = array(
+	$buffer   = multipart( $parts, $boundary );
+	$headers  = array(
 		'Authorization'  => 'Bearer ' . IPFS_NFT_STORAGE_KEY,
 		'Content-Type'   => 'multipart/form-data; boundary=' . $boundary,
 		'Content-Length' => strlen( $buffer ),
 	);
-	$result  = $api->post( '/upload', $buffer, $headers );
+
+	$result = $api->post( '/upload', $buffer, $headers );
 
 	// var_dump($result->decode_response()->value->cid);
 	// var_dump($result->decode_response()->value->files[0]->name);
@@ -45,4 +45,30 @@ function nft_storage_add_and_pin( $attachment_id, $version = IPFS_CID_VERSION ) 
 	$result->decode_response()->value->cid . '/' .
 	$result->decode_response()->value->files[0]->name
 	: $result->error;
+}
+
+/**
+ * IPFS add and pin file with NFT Storage
+ *
+ * @param string $attachment_id Id attachment file.
+ *
+ * @return string CID hash
+ */
+function nft_storage_add_and_pin( $attachment_id ) {
+	$api = new \RestClient( array( 'base_url' => 'https://api.nft.storage' ) );
+
+	$file     = file_get_contents( get_attached_file( $attachment_id ) );
+	$filename = get_attached_file_meta( $attachment_id )->filename;
+
+	$headers = array(
+		'Authorization' => 'Bearer ' . IPFS_NFT_STORAGE_KEY,
+	);
+
+	$result = $api->post( '/upload', $file, $headers );
+
+	// var_dump($result->decode_response()->value->cid);
+	// var_dump($result->decode_response()->value->files[0]->name);
+	// .
+
+	return ( 200 === $result->info->http_code ) ? $result->decode_response()->value->cid : $result->error;
 }


### PR DESCRIPTION
Suppression du répertoire (et nu nom de fichier) dans le stockage IPFS

Permet d'avoir un cid image unique !
