### PR TITLE
fix NftMintButton mint without properties

### DIFF
--- a/svelte/components/Nft/NftMintButton.svelte
+++ b/svelte/components/Nft/NftMintButton.svelte
@@ -70,7 +70,7 @@
 
       minting = 2;
 
-      const ipfsJson = await nftIpfsJson(alt, alt, ipfsImage, signerAddress, src, null, metadata);
+      const ipfsJson = await nftIpfsJson(alt, alt, ipfsImage, signerAddress, src, {}, metadata);
       // console.log("json", ipfsJson);
 
       minting = 3;


### PR DESCRIPTION
Fix NftMintButton when minting in medias in wordpress (minting without properties)