### PR TITLE
Wp setting mint only once

### DIFF
--- a/common/lib/common/kconfig.ts
+++ b/common/lib/common/kconfig.ts
@@ -390,6 +390,8 @@ const kredeumNftHttp = (chainId: number, nft: NftType): string => `${config.doma
 const kredeumNftWpUrl = (chainId: number, nft: NftType): string =>
   `./admin.php?page=nfts/${kredeumNftUrl(chainId, nft)}`;
 
+const nidTokredeumNftWPUrl = (nid: string): string => `./admin.php?page=nfts/#/${nid.replace("nft://", "")}`;
+
 // NFT URL
 const explorerNftUrl = (chainId: number, nft: NftType): string => {
   let url = "";
@@ -522,6 +524,7 @@ export {
   ipfsGetLink,
   ipfsGatewayUrl,
   ipfsGatewayLink,
+  nidTokredeumNftWPUrl,
   swarmGetLink,
   swarmLinkToUrlHttp,
   swarmCidToLink,

--- a/common/lib/nft/knft-mint.ts
+++ b/common/lib/nft/knft-mint.ts
@@ -1,4 +1,4 @@
-import type { JsonRpcSigner, TransactionResponse, TransactionReceipt, Log } from "@ethersproject/providers";
+import type { JsonRpcSigner, TransactionResponse, TransactionReceipt } from "@ethersproject/providers";
 import { ethers, BigNumber, Contract, constants, BigNumberish } from "ethers";
 
 import type { NftType } from "@lib/common/ktypes";

--- a/svelte/components/Nft/NftMintButton.svelte
+++ b/svelte/components/Nft/NftMintButton.svelte
@@ -3,7 +3,7 @@
 
   import type { NftType } from "@lib/common/ktypes";
   import { nftIpfsImage, nftIpfsJson, nftMint, nftMint4 } from "@lib/nft/knft-mint";
-  import { explorerTxLog, ipfsGatewayLink, urlToLink, kredeumNftWpUrl } from "@lib/common/kconfig";
+  import { explorerTxLog, ipfsGatewayLink, urlToLink, kredeumNftWpUrl, ipfsLinkToCid } from "@lib/common/kconfig";
 
   import { metamaskChainId, metamaskAccount, metamaskSigner } from "@main/metamask";
   import { collectionStore } from "@stores/collection/collection";
@@ -28,6 +28,8 @@
   let ipfsImage: string;
 
   let address: Readable<string>;
+
+  let refThis: HTMLElement;
 
   const nftMintTexts = [
     "Mint",
@@ -83,6 +85,13 @@
       mintedNft = await nftMint4($metamaskChainId, $address, mintingTxResp, ipfsJson, signerAddress);
       // console.log("mintedNft", mintedNft);
 
+      // Dispacth "token" event to be catched in wordpress/plugins/kredeum-nfts/admin/ajax/ajax.js
+      const event = new CustomEvent("token", {
+        detail: { nid: mintedNft.nid, pid: pid, cid: ipfsLinkToCid(mintedNft.ipfs) },
+        bubbles: true
+      });
+      refThis.dispatchEvent(event);
+
       minting = 5;
     } else {
       console.error("KredeumNftsMint ERROR : no src or collection address, impossible to mint!", src, $address);
@@ -92,7 +101,7 @@
   };
 </script>
 
-<main id="kredeum-mint">
+<main id="kredeum-mint" bind:this={refThis}>
   {#if display && src}
     <img {src} {alt} {width} /><br />
   {/if}

--- a/svelte/components/Nft/NftMintButton.svelte
+++ b/svelte/components/Nft/NftMintButton.svelte
@@ -120,14 +120,16 @@
         <button on:click={view} class="btn btn-small btn-sell" title="View in Explorer">VIEW NFT</button>
       {:else if 1 <= minting && minting <= 5}
         <div>
-          <button id="mint-button" class="btn btn-small btn-minting">MINTING {minting}...</button>
+          <button id="mint-button" class="btn btn-small btn-minting"
+            >MINTING {minting}/{nftMintTexts.length - 1}...</button
+          >
         </div>
         <div>
           <em>{nftMintTexts[minting]}</em>
         </div>
       {/if}
     {:else if nid}
-      <button on:click={nftLink} class="btn btn-small btn-sell" title="View in Explorer">NFT LINK</button>
+      <button on:click={nftLink} class="btn btn-small btn-sell" title="View in Explorer">VIEW NFT</button>
     {:else}
       <button id="mint-button-{pid || '0'}" on:click={mint} class="btn btn-small btn-mint"> MINT NFT </button>
     {/if}

--- a/svelte/components/Nft/NftMintButton.svelte
+++ b/svelte/components/Nft/NftMintButton.svelte
@@ -3,7 +3,14 @@
 
   import type { NftType } from "@lib/common/ktypes";
   import { nftIpfsImage, nftIpfsJson, nftMint, nftMint4 } from "@lib/nft/knft-mint";
-  import { explorerTxLog, ipfsGatewayLink, urlToLink, kredeumNftWpUrl, ipfsLinkToCid } from "@lib/common/kconfig";
+  import {
+    explorerTxLog,
+    ipfsGatewayLink,
+    urlToLink,
+    kredeumNftWpUrl,
+    ipfsLinkToCid,
+    nidTokredeumNftWPUrl
+  } from "@lib/common/kconfig";
 
   import { metamaskChainId, metamaskAccount, metamaskSigner } from "@main/metamask";
   import { collectionStore } from "@stores/collection/collection";
@@ -18,6 +25,7 @@
   export let metadata: string = "{}";
   export let alt: string = undefined;
   export let pid: string = undefined;
+  export let nid: string = undefined;
   export let width = 100;
   export let display = false;
   /////////////////////////////////////////////////
@@ -46,10 +54,10 @@
     // console.log("handleChange ~ address", $address);
   };
 
-  // const sell = (e: Event): void => {
-  //   e.preventDefault();
-  //   location.href = kredeumNftWpUrl($metamaskChainId, mintedNft);
-  // };
+  const nftLink = (e: Event): void => {
+    e.preventDefault();
+    location.href = nidTokredeumNftWPUrl(nid);
+  };
 
   const view = (e: Event): void => {
     e.preventDefault();
@@ -118,6 +126,8 @@
           <em>{nftMintTexts[minting]}</em>
         </div>
       {/if}
+    {:else if nid}
+      <button on:click={nftLink} class="btn btn-small btn-sell" title="View in Explorer">NFT LINK</button>
     {:else}
       <button id="mint-button-{pid || '0'}" on:click={mint} class="btn btn-small btn-mint"> MINT NFT </button>
     {/if}
@@ -142,6 +152,17 @@
     background-color: #2a81de;
     border: 0px;
     margin: 10px;
+    padding: 8px 15px;
+    border-radius: 360px;
+    border: none;
+    width: fit-content;
+    transition: all 300ms ease-in-out;
+    display: inline-block;
+    vertical-align: middle;
+    text-transform: uppercase;
+    font-weight: bold;
+    font-size: 12px;
+    cursor: pointer;
   }
   button.btn-mint {
     background-color: #2a81de;
@@ -155,6 +176,10 @@
     cursor: pointer;
   }
   button.btn-sell {
-    background-color: #36d06f;
+    background-color: #3acf6e;
+  }
+
+  button.btn-sell:hover {
+    background-color: #2aac57;
   }
 </style>

--- a/wordpress/plugins/kredeum-nfts/admin/ajax/ajax.js
+++ b/wordpress/plugins/kredeum-nfts/admin/ajax/ajax.js
@@ -21,18 +21,30 @@ function _ajax(data) {
 
 jQuery(document).ready(function () {
   // ACTION MINT_TOKEN
-  const targets = document.querySelectorAll(".kredeum-nfts-mint");
-  targets?.forEach(function (kredeumNftsMint) {
-    if (kredeumNftsMint.$on) {
-      kredeumNftsMint.$on("token", function (e) {
-        _ajax({
-          action: "token",
-          nid: e.detail.nid,
-          pid: kredeumNftsMint.pid
-        });
-      });
-    }
-  });
+  document.addEventListener('token', (e) => {
+    _ajax({
+      action: "token",
+      nid: e.detail.nid,
+      pid: e.detail.pid,
+      cid: e.detail.cid
+    });
+  })
+
+  // const targets = document.querySelectorAll(".kredeum-nfts-mint");
+  // console.log("targets", targets)
+  
+  // targets?.forEach(function (kredeumNftsMint) {
+  //   if (kredeumNftsMint.$on) {
+  //     kredeumNftsMint.$on("token", function (e) {
+  //       console.log("token ! ", e.detail);
+  //       _ajax({
+  //         action: "token",
+  //         nid: e.detail.nid,
+  //         pid: kredeumNftsMint.pid
+  //       });
+  //     });
+  //   }
+  // });
 
   const kredeumNfts = document.querySelector("#kredeum-app");
   if (kredeumNfts?.$on) {

--- a/wordpress/plugins/kredeum-nfts/admin/ajax/ajax.php
+++ b/wordpress/plugins/kredeum-nfts/admin/ajax/ajax.php
@@ -32,7 +32,7 @@ add_action(
 			$pid = sanitize_text_field( wp_unslash( $_POST['pid'] ) );
 			$nid = sanitize_text_field( wp_unslash( $_POST['nid'] ) );
 			$cid = sanitize_text_field( wp_unslash( $_POST['cid'] ) );
-			add_post_meta( $pid, '_kre_nid', $nid, true );
+			update_post_meta( $pid, '_kre_nid', $nid );
 			update_post_meta( $pid, '_kre_cid', $cid );
 
 		};

--- a/wordpress/plugins/kredeum-nfts/admin/ajax/ajax.php
+++ b/wordpress/plugins/kredeum-nfts/admin/ajax/ajax.php
@@ -28,10 +28,13 @@ add_action(
 	function () {
 		check_ajax_referer( 'ajax-token', 'security' );
 
-		if ( isset( $_POST['pid'] ) && isset( $_POST['nid'] ) ) {
+		if ( isset( $_POST['pid'] ) && isset( $_POST['nid'] ) && isset( $_POST['cid'] ) ) {
 			$pid = sanitize_text_field( wp_unslash( $_POST['pid'] ) );
 			$nid = sanitize_text_field( wp_unslash( $_POST['nid'] ) );
-			 add_post_meta( $pid, '_kre_nid', $nid, true );
+			$cid = sanitize_text_field( wp_unslash( $_POST['cid'] ) );
+			add_post_meta( $pid, '_kre_nid', $nid, true );
+			update_post_meta( $pid, '_kre_cid', $cid );
+
 		};
 
 		echo esc_html( "wp_ajax_token $pid $nid" );

--- a/wordpress/plugins/kredeum-nfts/admin/media-list/column.php
+++ b/wordpress/plugins/kredeum-nfts/admin/media-list/column.php
@@ -34,35 +34,23 @@ add_action(
 		}
 
 		if ( 'kre-nft' === $name ) {
+			$nid = "";
 			if ( $post->_kre_nid ) {
-				$styles = "text-decoration: none;
-				padding: 8px 15px;
-				border-radius: 360px;
-				border: none;
-				color: white;
-				background-color: #3acf6e;
-				width: fit-content;
-				transition: all 300ms ease-in-out;
-				display: inline-block;
-				vertical-align: middle;
-				text-transform: uppercase;
-				font-weight: bold;
-				font-size: 12px;";
-				printf( '<a style="' . $styles . '" href="/wp-admin/admin.php?page=nfts/#/' . esc_attr( str_replace( 'nft://', '', $post->_kre_nid ) ) . '" nid=' . esc_attr( $post->_kre_nid ) . '>NFT link</a>' );
-			} else {
-
-				$metadata = get_metadata( 'post', $post->ID );
-
-				printf(
-					'<div class="kredeum-nfts-mint"'
-					// . ' ipfs="' . esc_url( url( $post->_kre_cid ) ) . '"'
-					// . ' cid="' . esc_url( $post->_kre_cid ) . '"'
-					. ' src="' . esc_attr( wp_get_attachment_url( $post->ID ) ) . '"'
-					. ' pid="' . esc_attr( $post->ID ) . '"'
-					. ' metadata="' . esc_attr( wp_json_encode( $metadata ) ) . '"'
-					. ' alt="' . esc_attr( $post->post_title ) . '"/>'
-				);
+				$nid = $post->_kre_nid;
 			}
+			
+			$metadata = get_metadata( 'post', $post->ID );
+
+			printf(
+				'<div class="kredeum-nfts-mint"'
+				// . ' ipfs="' . esc_url( url( $post->_kre_cid ) ) . '"'
+				// . ' cid="' . esc_url( $post->_kre_cid ) . '"'
+				. ' src="' . esc_attr( wp_get_attachment_url( $post->ID ) ) . '"'
+				. ' pid="' . esc_attr( $post->ID ) . '"'
+				. ' nid="' . esc_attr( $nid ) . '"'
+				. ' metadata="' . esc_attr( wp_json_encode( $metadata ) ) . '"'
+				. ' alt="' . esc_attr( $post->post_title ) . '"/>'
+			);
 		}
 	}
 );

--- a/wordpress/plugins/kredeum-nfts/admin/media-list/column.php
+++ b/wordpress/plugins/kredeum-nfts/admin/media-list/column.php
@@ -34,11 +34,11 @@ add_action(
 		}
 
 		if ( 'kre-nft' === $name ) {
-			$nid = "";
+			$nid = '';
 			if ( $post->_kre_nid ) {
 				$nid = $post->_kre_nid;
 			}
-			
+
 			$metadata = get_metadata( 'post', $post->ID );
 
 			printf(

--- a/wordpress/plugins/kredeum-nfts/admin/media-list/column.php
+++ b/wordpress/plugins/kredeum-nfts/admin/media-list/column.php
@@ -35,7 +35,7 @@ add_action(
 
 		if ( 'kre-nft' === $name ) {
 			if ( $post->_kre_nid ) {
-				printf( '<a href="/wp-admin/admin.php?page=nfts" nid=' . esc_attr( $post->_kre_nid ) . '>NFT link</a>' );
+				printf( '<a href="/wp-admin/admin.php?page=nfts/#/' . esc_attr( str_replace( 'nft://', '', $post->_kre_nid ) ) . '" nid=' . esc_attr( $post->_kre_nid ) . '>NFT link</a>' );
 			} else {
 
 				$metadata = get_metadata( 'post', $post->ID );

--- a/wordpress/plugins/kredeum-nfts/admin/media-list/column.php
+++ b/wordpress/plugins/kredeum-nfts/admin/media-list/column.php
@@ -35,7 +35,20 @@ add_action(
 
 		if ( 'kre-nft' === $name ) {
 			if ( $post->_kre_nid ) {
-				printf( '<a href="/wp-admin/admin.php?page=nfts/#/' . esc_attr( str_replace( 'nft://', '', $post->_kre_nid ) ) . '" nid=' . esc_attr( $post->_kre_nid ) . '>NFT link</a>' );
+				$styles = "text-decoration: none;
+				padding: 8px 15px;
+				border-radius: 360px;
+				border: none;
+				color: white;
+				background-color: #3acf6e;
+				width: fit-content;
+				transition: all 300ms ease-in-out;
+				display: inline-block;
+				vertical-align: middle;
+				text-transform: uppercase;
+				font-weight: bold;
+				font-size: 12px;";
+				printf( '<a style="' . $styles . '" href="/wp-admin/admin.php?page=nfts/#/' . esc_attr( str_replace( 'nft://', '', $post->_kre_nid ) ) . '" nid=' . esc_attr( $post->_kre_nid ) . '>NFT link</a>' );
 			} else {
 
 				$metadata = get_metadata( 'post', $post->ID );


### PR DESCRIPTION
Mint only once in WP media :

- update NFT nid
- update NFT CID

Be carefull after Mint if you click on "view nft" button, you see Nft in Dapp, and if you make page back, you come back on WP's medias page with original Mint button and can mint again. Should we reload page after WP's Medias page ? 