### PR TITLE
Fix wordpress media table display

### DIFF
--- a/gulp/scss/front.scss
+++ b/gulp/scss/front.scss
@@ -78,7 +78,6 @@
 .media {
   @include border-radius;
   overflow: hidden;
-  display: inline-block;
   vertical-align: middle;
   width: 100%;
 


### PR DESCRIPTION
Fix wordpress media table display

Removed just one css property that seems not to be used anymore an wich is in conflict with wordpress class