### PR TITLE
Fix git submodules

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -4,6 +4,7 @@
 [submodule "contracts/lib/OpenNFTs"]
 	path = contracts/lib/OpenNFTs
 	url = https://github.com/kredeum/OpenNFTs
+  tag = v0.11.0
 [submodule "contracts/lib/openzeppelin-contracts-upgradeable"]
 	path = contracts/lib/openzeppelin-contracts-upgradeable
 	url = https://github.com/openzeppelin/openzeppelin-contracts-upgradeable


### PR DESCRIPTION
Fix git submodules 

Some wrong config in gitsubmodules => ok after complete git reconfig
OpenNFTs version differs (must be v01.11.0} as present twice : in node_modules for hardhat, in lib for foundry  