### PR TITLE
Fix audio video

### DIFF
--- a/gulp/scss/front.scss
+++ b/gulp/scss/front.scss
@@ -248,6 +248,10 @@
         position: relative;
       }
 
+      .kre-media-line {
+        display: inline-block;
+      }
+
       .detail {
         position: absolute;
         left: 0;

--- a/svelte/components/Input/InputVideoMint.svelte
+++ b/svelte/components/Input/InputVideoMint.svelte
@@ -39,7 +39,7 @@
   <div class="box-file">
     {#if video}
       <div class="kre-video-mint">
-        <MediaVideo src={video} mode="line" small={true} controls={true} muted={true} />
+        <MediaVideo src={video} mode="line" />
 
         <span class="kre-delete-file" on:click={resetFileVideo} on:keydown={resetFileVideo}
           ><i class="fa fa-trash" aria-hidden="true" /></span

--- a/svelte/components/Main/Dapp.svelte
+++ b/svelte/components/Main/Dapp.svelte
@@ -41,6 +41,9 @@
   let refreshAll: Writable<number> = writable(1);
   setContext("refreshAll", refreshAll);
 
+  let toPlayTokenID: Writable<string> = writable("");
+  setContext("toPlayTokenID", toPlayTokenID);
+
   $: refresh = refreshingCollections || refreshingNfts;
 
   // SET chainId on memataskChainId change

--- a/svelte/components/Main/OpenSky.svelte
+++ b/svelte/components/Main/OpenSky.svelte
@@ -26,6 +26,9 @@
   let refreshAll: Writable<number> = writable(1);
   setContext("refreshAll", refreshAll);
 
+  let toPlayTokenID: Writable<string> = writable("");
+  setContext("toPlayTokenID", toPlayTokenID);
+
   const setNetwork = async () => {
     if (chainId != $metamaskChainId) {
       await metamaskSwitchChain(chainId);

--- a/svelte/components/Media/Media.svelte
+++ b/svelte/components/Media/Media.svelte
@@ -21,7 +21,7 @@
   let gridScale = mode.startsWith("grid") ? " a-simul-cursor" : "";
 </script>
 
-<div id="media-{mode}-{tokenID}" class="media {cssMedia} media-{nftMediaContentType($nft)}{gridScale}">
+<div id="media-{mode}-{tokenID}" class="media kre-media-{mode} {cssMedia} media-{nftMediaContentType($nft)}{gridScale}">
   {#if nftMediaAnimationUrl($nft)}
     <MediaAudio
       animation_url={nftMediaAnimationUrl($nft)}

--- a/svelte/components/Media/MediaAudio.svelte
+++ b/svelte/components/Media/MediaAudio.svelte
@@ -4,7 +4,7 @@
 
   import MediaImage from "./MediaImage.svelte";
   /////////////////////////////////////////////////
-  //  <DisplayAudio {src} {animation_url} {mode}? {alt}? {index}? {paused}? />
+  //  <DisplayAudio {src} {tokenID} {animation_url} {mode}? {alt}? {paused}? />
   // Display a player audio with its cover image according to its entering parameters
   /////////////////////////////////////////////////
   export let src: string;
@@ -49,13 +49,45 @@
   </audio>
   <button
     on:click|stopPropagation={togglePlayAudio}
-    class="krd-play-audio-button {mode === 'line' && 'krd-play-audio-line-button'}"
+    class="kre-play-media-button {mode === 'line' && 'kre-play-media-line-button'}"
   >
     <i class="fa {paused ? 'fa-play-circle' : 'fa-pause-circle'} video-play-icon" />
   </button>
 {/if}
 
 <style>
+  .kre-play-media-button {
+    position: absolute;
+    bottom: 2%;
+    right: 2%;
+    background-color: transparent;
+    color: white;
+    border: none;
+    font-size: 2.7rem;
+  }
+
+  .kre-play-media-button i {
+    position: absolute;
+    bottom: 0;
+    right: 0;
+    background-color: lightgray;
+    border-radius: 50%;
+    cursor: pointer;
+  }
+
+  .kre-play-media-line-button {
+    top: 65px;
+    left: 35px;
+    bottom: unset;
+    width: 2.3rem;
+    font-size: 2.3rem;
+  }
+
+  .kre-play-media-line-button i {
+    border: 1px solid lightgray;
+  }
+
+  /* Specific for audio */
   audio::-webkit-media-controls-enclosure {
     border-radius: 6px;
     background-color: rgba(0, 0, 0, 0.5);
@@ -84,32 +116,4 @@
       background-color: rgba(0, 0, 0, 1);
     }
   } */
-
-  .krd-play-audio-button {
-    position: absolute;
-    bottom: 9px;
-    left: 0;
-    background-color: transparent;
-    color: white;
-    border: none;
-    font-size: 3.5rem;
-  }
-
-  .krd-play-audio-button i {
-    position: absolute;
-    bottom: 0;
-    background-color: lightgray;
-    border-radius: 50%;
-    cursor: pointer;
-  }
-
-  .krd-play-audio-line-button {
-    top: 65px;
-    left: 35px;
-    bottom: unset;
-  }
-
-  .krd-play-audio-line-button i {
-    border: 1px solid lightgray;
-  }
 </style>

--- a/svelte/components/Media/MediaAudio.svelte
+++ b/svelte/components/Media/MediaAudio.svelte
@@ -4,7 +4,7 @@
 
   import MediaImage from "./MediaImage.svelte";
   /////////////////////////////////////////////////
-  //  <DisplayAudio {src} {animation_url} {mode}? {alt}? {index}? {small}? {paused}? />
+  //  <DisplayAudio {src} {animation_url} {mode}? {alt}? {index}? {paused}? />
   // Display a player audio with its cover image according to its entering parameters
   /////////////////////////////////////////////////
   export let src: string;
@@ -12,48 +12,47 @@
   export let animation_url: string;
   export let mode: string = "line";
   export let alt: string = "Cover image";
-  export let small: boolean = true;
   export let paused: boolean = true;
 
   let toPlayTokenID: Writable<string> = getContext("toPlayTokenID");
-  $: paused = $toPlayTokenID !== tokenID;
-  const playAudio = () => {
-    if (mode === "zoom") {
+
+  const togglePlayAudio = () => {
+    paused = !paused;
+    if (toPlayTokenID) {
       $toPlayTokenID = $toPlayTokenID !== tokenID ? tokenID : "";
     }
   };
+
+  $: if (toPlayTokenID && $toPlayTokenID !== tokenID) paused = true;
+  $: mode && resetToPlayTokenID();
+  const resetToPlayTokenID = () => {
+    if (toPlayTokenID) $toPlayTokenID = "";
+  };
 </script>
 
-<div class="audio-cover-image {small ? '' : 'audioDeployed'}">
+<div class="audio-cover-image">
   <MediaImage {src} {alt} />
 </div>
-{#if small}
-  {#if mode === "line"}
-    <audio preload="none" bind:paused src={animation_url}>
-      <track kind="captions" />
-      Your browser does not support the
-      <code>audio</code> element.
-    </audio>
-    <button on:click={playAudio} class="krd-play-audio-button krd-play-audio-line-button">
-      <i class="fa {paused ? 'fa-play-circle' : 'fa-pause-circle'} video-play-icon" />
-    </button>
-  {:else}
-    <!-- <audio controls preload="none" bind:this={player} src={animation_url}> -->
-    <audio controls preload="none" bind:paused src={animation_url}>
-      <!-- <audio controls preload="none" src={animation_url}> -->
-      <track kind="captions" />
-      Your browser does not support the
-      <code>audio</code> element.
-    </audio>
-    <button on:click={playAudio} class="krd-play-audio-button">
-      <i class="fa {paused ? 'fa-play-circle' : 'fa-pause-circle'} video-play-icon" />
-    </button>
-  {/if}
-{:else}
-  <audio controls autoplay src={animation_url}>
+
+{#if mode == "zoom"}
+  <audio class="kre-zoom-audio" controls autoplay src={animation_url}>
     Your browser does not support the
     <code>audio</code> element.
   </audio>
+{:else}
+  <!-- <audio controls preload="none" bind:this={player} src={animation_url}> -->
+  <audio preload="none" bind:paused src={animation_url}>
+    <!-- <audio controls preload="none" src={animation_url}> -->
+    <track kind="captions" />
+    Your browser does not support the
+    <code>audio</code> element.
+  </audio>
+  <button
+    on:click|stopPropagation={togglePlayAudio}
+    class="krd-play-audio-button {mode === 'line' && 'krd-play-audio-line-button'}"
+  >
+    <i class="fa {paused ? 'fa-play-circle' : 'fa-pause-circle'} video-play-icon" />
+  </button>
 {/if}
 
 <style>
@@ -71,25 +70,20 @@
     height: 100%;
   }
 
-  .audio-cover-image:not(.audioDeployed) + audio {
+  .kre-zoom-audio {
+    width: 50%;
     position: absolute;
-    bottom: 0;
+    bottom: 60px;
     left: 50%;
-    transform: translate(-50%, 0%);
-    width: 100%;
-    height: 54px;
+    transform: translate(-50%, 0);
   }
 
-  @supports (-moz-appearance: none) {
+  /* @supports (-moz-appearance: none) {
     .audio-cover-image:not(.audioDeployed) + audio {
       padding: 0px 0 7px 0;
       background-color: rgba(0, 0, 0, 1);
     }
-  }
-
-  .audioDeployed + audio {
-    transform: translate(50%, 15%);
-  }
+  } */
 
   .krd-play-audio-button {
     position: absolute;

--- a/svelte/components/Media/MediaPreview.svelte
+++ b/svelte/components/Media/MediaPreview.svelte
@@ -10,7 +10,7 @@
   import { nftStore } from "@stores/nft/nft";
 
   /////////////////////////////////////////////////
-  // <MediaPreview {chainId} {address} {tokenID} />
+  // <MediaPreview {chainId} {address} {tokenID} {mode}? />
   // Display a clickable preview of media opening a zoom modal with full media
   // Modal closing by clickoutside
   /////////////////////////////////////////////////////////////////

--- a/svelte/components/Media/MediaPreview.svelte
+++ b/svelte/components/Media/MediaPreview.svelte
@@ -1,8 +1,13 @@
 <script lang="ts">
-  import { fade } from "svelte/transition";
+  import type { Writable } from "svelte/store";
+  import { getContext } from "svelte";
 
   import Media from "./Media.svelte";
+  import { fade } from "svelte/transition";
+
   import { clickOutside } from "@helpers/clickOutside";
+  import { nftMediaAnimationUrl, nftMediaContentType } from "@lib/nft/nft";
+  import { nftStore } from "@stores/nft/nft";
 
   /////////////////////////////////////////////////
   // <MediaPreview {chainId} {address} {tokenID} />
@@ -14,14 +19,25 @@
   export let tokenID: string;
   export let mode: string = undefined;
   /////////////////////////////////////////////////////////////////
+  let toPlayTokenID: Writable<string> = getContext("toPlayTokenID");
+
+  $: nft = nftStore(chainId, address, tokenID);
+  $: isAnimationMedia = nftMediaContentType($nft) === "video" || nftMediaAnimationUrl($nft) !== "";
 
   let popupOpen = false;
-  const popupToggle = (): boolean => (popupOpen = !popupOpen);
+  const popupToggle = (): void => {
+    if (toPlayTokenID) $toPlayTokenID = "";
+    popupOpen = !popupOpen;
+  };
 </script>
 
 <div class="media-zoom">
   <div class="media">
-    <span class="krd-pointer zoom-hover" on:click={popupToggle} on:keydown={popupToggle}>
+    <span
+      class="krd-pointer {isAnimationMedia ? 'no-zoom-hover' : 'zoom-hover'}"
+      on:click={popupToggle}
+      on:keydown={popupToggle}
+    >
       <i class="fas fa-search" />
       <Media {chainId} {address} {tokenID} {mode} />
     </span>
@@ -91,5 +107,9 @@
   .media-zoom .media .zoom-hover:hover::after,
   .media-zoom .media .zoom-hover:hover .fas {
     opacity: 1;
+  }
+
+  .krd-pointer.no-zoom-hover i.fas {
+    display: none;
   }
 </style>

--- a/svelte/components/Media/MediaVideo.svelte
+++ b/svelte/components/Media/MediaVideo.svelte
@@ -3,63 +3,57 @@
   import type { Writable } from "svelte/store";
 
   /////////////////////////////////////////////////
-  //  <MediaVideo {src} {tokenID}? {mode}? {paused}? {small}? {controls}? {muted}? />
+  //  <MediaVideo {src} {tokenID}? {mode}? {paused}? />
   // Display a Video according to its entering parameters
   /////////////////////////////////////////////////
   export let src: string;
   export let tokenID: string = undefined;
   export let mode: string = undefined;
   export let paused: boolean = true;
-  export let small: boolean = false;
-  export let controls: boolean = false;
-  export let muted: boolean = false;
 
   let toPlayTokenID: Writable<string> = getContext("toPlayTokenID");
-  $: paused = $toPlayTokenID !== tokenID;
-  const playVideo = () => {
+  const togglePlayVideo = () => {
     paused = !paused;
-    $toPlayTokenID = $toPlayTokenID !== tokenID ? tokenID : "";
+    if (toPlayTokenID) {
+      $toPlayTokenID = $toPlayTokenID !== tokenID ? tokenID : "";
+    }
   };
-  $: console.log("playAudio ~ mode:", mode);
+
+  $: if (toPlayTokenID && $toPlayTokenID !== tokenID) paused = true;
+  $: mode && resetToPlayTokenID();
+  const resetToPlayTokenID = () => {
+    if (toPlayTokenID) $toPlayTokenID = "";
+  };
 </script>
 
-<!-- {#if small} -->
-{#if mode.startsWith("grid")}
-  <video autoplay={false} {src} preload="metadata" loop playsinline style="border-radius: initial;" bind:paused>
-    <track kind="captions" />
-  </video>
-  <button on:click|stopPropagation={playVideo} class="video-play-button">
-    <i class="fa {paused ? 'fa-play-circle' : 'fa-pause-circle'} video-play-icon" />
-  </button>
-{:else if mode === "line"}
+{#if mode == "zoom"}
   <!-- svelte-ignore a11y-media-has-caption -->
-  <video autoplay={false} playsinline style="border-radius: initial;" {controls} {muted}>
+  <video autoplay={true} preload="metadata" controls loop playsinline style="border-radius: initial;">
     <source {src} type="video/mp4" /></video
   >
 {:else}
-  <!-- svelte-ignore a11y-media-has-caption -->
-  <video autoplay={true} preload="metadata" controls loop playsinline muted style="border-radius: initial;">
-    <source {src} type="video/mp4" /></video
-  >
-{/if}
-
-<!-- {:else} -->
-<!-- svelte-ignore a11y-media-has-caption -->
-<!-- <video
-    autoplay={true}
-    controls
-    controlslist="nodownload"
+  <video
+    {src}
+    autoplay={mode === "detail"}
+    muted={mode === "detail"}
+    preload="metadata"
     loop
     playsinline
-    preload="metadata"
     style="border-radius: initial;"
+    bind:paused
   >
-    <source {src} type="video/mp4" /></video
+    <track kind="captions" />
+  </video>
+  <button
+    on:click|stopPropagation={togglePlayVideo}
+    class="kre-play-media-button {mode === 'line' && 'kre-play-media-line-button'}"
   >
-{/if} -->
+    <i class="fa {paused ? 'fa-play-circle' : 'fa-pause-circle'} video-play-icon" />
+  </button>
+{/if}
 
 <style>
-  .video-play-button {
+  /* .video-play-button {
     position: absolute;
     bottom: 2%;
     right: 2%;
@@ -75,5 +69,37 @@
     right: 0;
     background-color: lightgray;
     border-radius: 50%;
+  } */
+
+  /*  */
+  .kre-play-media-button {
+    position: absolute;
+    bottom: 2%;
+    right: 2%;
+    background-color: transparent;
+    color: white;
+    border: none;
+    font-size: 2.7rem;
+  }
+
+  .kre-play-media-button i {
+    position: absolute;
+    bottom: 0;
+    right: 0;
+    background-color: lightgray;
+    border-radius: 50%;
+    cursor: pointer;
+  }
+
+  .kre-play-media-line-button {
+    top: 65px;
+    left: 35px;
+    bottom: unset;
+    width: 2.3rem;
+    font-size: 2.3rem;
+  }
+
+  .kre-play-media-line-button i {
+    border: 1px solid lightgray;
   }
 </style>

--- a/svelte/components/Media/MediaVideo.svelte
+++ b/svelte/components/Media/MediaVideo.svelte
@@ -53,25 +53,6 @@
 {/if}
 
 <style>
-  /* .video-play-button {
-    position: absolute;
-    bottom: 2%;
-    right: 2%;
-    background-color: transparent;
-    color: white;
-    border: none;
-    font-size: 4rem;
-  }
-
-  .video-play-button i {
-    position: absolute;
-    bottom: 0;
-    right: 0;
-    background-color: lightgray;
-    border-radius: 50%;
-  } */
-
-  /*  */
   .kre-play-media-button {
     position: absolute;
     bottom: 2%;

--- a/svelte/components/Media/MediaVideo.svelte
+++ b/svelte/components/Media/MediaVideo.svelte
@@ -20,30 +20,32 @@
     paused = !paused;
     $toPlayTokenID = $toPlayTokenID !== tokenID ? tokenID : "";
   };
+  $: console.log("playAudio ~ mode:", mode);
 </script>
 
-{#if small}
-  {#if mode.startsWith("grid")}
-    <video autoplay={false} {src} preload="metadata" loop playsinline style="border-radius: initial;" bind:paused>
-      <track kind="captions" />
-    </video>
-    <button on:click={playVideo} class="video-play-button">
-      <i class="fa {paused ? 'fa-play-circle' : 'fa-pause-circle'} video-play-icon" />
-    </button>
-  {:else if mode === "line"}
-    <!-- svelte-ignore a11y-media-has-caption -->
-    <video autoplay={false} playsinline style="border-radius: initial;" {controls} {muted}>
-      <source {src} type="video/mp4" /></video
-    >
-  {:else}
-    <!-- svelte-ignore a11y-media-has-caption -->
-    <video autoplay={true} preload="metadata" controls loop playsinline muted style="border-radius: initial;">
-      <source {src} type="video/mp4" /></video
-    >
-  {/if}
+<!-- {#if small} -->
+{#if mode.startsWith("grid")}
+  <video autoplay={false} {src} preload="metadata" loop playsinline style="border-radius: initial;" bind:paused>
+    <track kind="captions" />
+  </video>
+  <button on:click|stopPropagation={playVideo} class="video-play-button">
+    <i class="fa {paused ? 'fa-play-circle' : 'fa-pause-circle'} video-play-icon" />
+  </button>
+{:else if mode === "line"}
+  <!-- svelte-ignore a11y-media-has-caption -->
+  <video autoplay={false} playsinline style="border-radius: initial;" {controls} {muted}>
+    <source {src} type="video/mp4" /></video
+  >
 {:else}
   <!-- svelte-ignore a11y-media-has-caption -->
-  <video
+  <video autoplay={true} preload="metadata" controls loop playsinline muted style="border-radius: initial;">
+    <source {src} type="video/mp4" /></video
+  >
+{/if}
+
+<!-- {:else} -->
+<!-- svelte-ignore a11y-media-has-caption -->
+<!-- <video
     autoplay={true}
     controls
     controlslist="nodownload"
@@ -54,7 +56,7 @@
   >
     <source {src} type="video/mp4" /></video
   >
-{/if}
+{/if} -->
 
 <style>
   .video-play-button {

--- a/svelte/components/Nft/NftMintPopup.svelte
+++ b/svelte/components/Nft/NftMintPopup.svelte
@@ -408,7 +408,7 @@
         {:else if S0_START < minting && minting <= S5_MINTED}
           <div class="media media-photo">
             {#if inputMediaType === "video"}
-              <MediaVideo {src} mode="line" small={true} controls={true} />
+              <MediaVideo {src} mode="line" />
             {:else}
               <img {src} alt="nft" />
             {/if}

--- a/svelte/components/Nft/NftMintPopup.svelte
+++ b/svelte/components/Nft/NftMintPopup.svelte
@@ -408,7 +408,7 @@
         {:else if S0_START < minting && minting <= S5_MINTED}
           <div class="media media-photo">
             {#if inputMediaType === "video"}
-              <MediaVideo {src} small={true} />
+              <MediaVideo {src} mode="line" small={true} controls={true} />
             {:else}
               <img {src} alt="nft" />
             {/if}

--- a/svelte/components/Nfts/NftsGrid.svelte
+++ b/svelte/components/Nfts/NftsGrid.svelte
@@ -23,7 +23,7 @@
 <div class="row grid-krd">
   {#if nfts?.size > 0}
     {#each [...nfts.values()] as nft}
-      <div class={colClass(mode)} on:click={() => (tokenID = nft.tokenID)}>
+      <div class={colClass(mode)} on:click={() => (tokenID = nft.tokenID)} on:keydown={() => (tokenID = nft.tokenID)}>
         <Nft chainId={nft.chainId} address={nft.address} tokenID={nft.tokenID} {owner} {mode} />
       </div>
     {/each}

--- a/svelte/components/Nfts/NftsGrid.svelte
+++ b/svelte/components/Nfts/NftsGrid.svelte
@@ -23,7 +23,7 @@
 <div class="row grid-krd">
   {#if nfts?.size > 0}
     {#each [...nfts.values()] as nft}
-      <div class={colClass(mode)} on:mousedown={() => (tokenID = nft.tokenID)}>
+      <div class={colClass(mode)} on:click={() => (tokenID = nft.tokenID)}>
         <Nft chainId={nft.chainId} address={nft.address} tokenID={nft.tokenID} {owner} {mode} />
       </div>
     {/each}


### PR DESCRIPTION
Fix audio & video display

I set the context of "toPlayTokenID" in both Dapp.svelte & OpenSky.svelte components instead of Nfts.svelte to permit to stop the media when we open the zoom popup. 

I purposely made two almost identical components for audio and video to make it easy to make one, but i didn't have enough time.

For this reason, there is css repetition in both components, because i choose to left those styles in this component, because it can't really be used anywhere else.

You can test on dapp in detail, zoom, grid or line mode & on Wordpress front with OpenSky shortcode for one or multiple Nfts. The comportement is different when you click on audio/video image in grid mode in dapp and when you click on audio/video image on opensky shortcode. 

P.S : for a better experience, think to re-build styles... ;)