### PR TITLE
Add storage options

### DIFF
--- a/common/config/config.handlebars.json
+++ b/common/config/config.handlebars.json
@@ -10,6 +10,8 @@
       "nftStorageKey": "{{NFT_STORAGE_KEY}}"
     },
     "swarm": {
+      "apiEndpoint": "{{SWARM_END_POINT}}",
+      "apiKey": "{{GATEWAY_SWARM_BATCH_ID}}",
       "gateway": "https://api.gateway.ethswarm.org/bzz"
     }
   },

--- a/common/lib/common/beejs.ts
+++ b/common/lib/common/beejs.ts
@@ -1,14 +1,27 @@
+import type { StorageOptionType, OptionType } from "@lib/common/types";
+
 import { Bee } from "@ethersphere/bee-js";
-import { DEFAULT_NAME, swarmServer, SWARM_GATEWAY } from "@lib/common/config";
+import { DEFAULT_NAME, config } from "@lib/common/config";
 
 // const DEFAULT_NODE_URL = "http://localhost:1633";
-const KRD_BATCH_ID = "0000000000000000000000000000000000000000000000000000000000000000";
+// test batchID : 66048555f07597e20c8138ff00c64a4287841c68cd1974ff801d2c95864c7ecd
+const KRD_BATCH_ID = config.storage.swarm.apiKey;
 
 const getBee = (nodeUrl: string): Bee => {
-  return new Bee(nodeUrl ? nodeUrl : swarmServer(SWARM_GATEWAY));
+  return new Bee(nodeUrl ? nodeUrl : config.storage.swarm.apiEndpoint);
 };
 
-const swarmUploadFile = async (file: File | string, batchId = "", nodeUrl = ""): Promise<string> => {
+// const swarmUploadFile = async (file: File | string, batchId = "", nodeUrl = ""): Promise<string> => {
+const swarmUploadFile = async (
+  file: File | string,
+  storageOption: StorageOptionType = { default: "swarm" }
+): Promise<string> => {
+  const swarmStorage: OptionType | undefined = storageOption?.swarm;
+  const batchId = swarmStorage?.apiKey;
+  const nodeUrl = swarmStorage?.apiEndpoint || "";
+  console.log("swarmUploadFile ~ batchId:", batchId);
+  console.log("swarmUploadFile ~ nodeUrl:", nodeUrl);
+
   const bee: Bee = getBee(nodeUrl);
 
   const isFile = file instanceof File;

--- a/common/lib/common/types.ts
+++ b/common/lib/common/types.ts
@@ -131,6 +131,21 @@ type swarmType = {
 type storageType = XOR<ipfsType, swarmType>;
 
 ///////////////////////////////////////////////////
+// Upload storage Options parameters for Ipfs | Swarm | arweave
+///////////////////////////////////////////////////
+type OptionType = {
+  apiEndpoint: string;
+  apiKey: string;
+  gateway: string;
+};
+
+type StorageOptionType = {
+  default: string;
+  ipfs?: OptionType;
+  swarm?: OptionType;
+  arweave?: OptionType;
+};
+///////////////////////////////////////////////////
 
 type NftMetadata = {
   name?: string;
@@ -207,6 +222,8 @@ export type {
   NetworkWriteableFieldsType,
   ABIS,
   NftMetadata,
+  OptionType,
+  StorageOptionType,
   IOpenNFTsKeys,
   IErcKeys,
   RefPageType

--- a/common/lib/nft/storage/nft-ipfs.ts
+++ b/common/lib/nft/storage/nft-ipfs.ts
@@ -1,4 +1,4 @@
-import type { NftType, Properties } from "@lib/common/types";
+import type { NftType, Properties, StorageOptionType } from "@lib/common/types";
 
 import NftStorage from "@lib/nft/storage/nft-storage";
 import { ipfsGatewayUrl, textShort, DEFAULT_NAME } from "@lib/common/config";
@@ -7,8 +7,11 @@ let nftStorage: NftStorage;
 
 ///////////////////////////////////////////////////////////////////////////////////
 // GET ipfs image uri
-const nftIpfsImageUri = async (image: string, key = ""): Promise<string> => {
-  nftStorage = nftStorage || new NftStorage(key);
+const nftIpfsImageUri = async (
+  image: string,
+  storageOption: StorageOptionType = { default: "ipfs" }
+): Promise<string> => {
+  nftStorage = nftStorage || new NftStorage(storageOption?.ipfs?.apiKey || "");
   const ipfsImageCid = await nftStorage.pinUrl(image);
   const ipfsImageUri = ipfsImageCid && `ipfs://${ipfsImageCid}`;
 
@@ -25,7 +28,8 @@ const nftIpfsTokenUri = async (
   image = "",
   metadata = "{}",
   properties: Properties = {},
-  animation_url = ""
+  animation_url = "",
+  storageOption: StorageOptionType = { default: "ipfs" }
 ): Promise<string> => {
   // console.log("nftIpfsTokenUri", name, imageUri, address, image, metadata);
 

--- a/common/lib/nft/storage/nft-storage.ts
+++ b/common/lib/nft/storage/nft-storage.ts
@@ -1,7 +1,9 @@
+import { config } from "@lib/common/config";
+
 import Ipfs from "@lib/common/ipfs";
 
 const nftStorageEndpoint = "https://api.nft.storage";
-const keyDefault: string = process.env.NFT_STORAGE_KEY || "";
+const keyDefault: string = config.storage.ipfs.nftStorageKey || "";
 
 type NftStorageResponse = {
   ok: boolean;

--- a/common/lib/nft/storage/nft-swarm.ts
+++ b/common/lib/nft/storage/nft-swarm.ts
@@ -1,4 +1,4 @@
-import type { NftType, Properties } from "@lib/common/types";
+import type { NftType, Properties, StorageOptionType } from "@lib/common/types";
 
 import { DEFAULT_NAME, textShort, ipfsGatewayUrl, swarmGatewayUrl } from "@lib/common/config";
 
@@ -18,7 +18,10 @@ const _srcToFileType = async (src: string): Promise<File> => {
 // Params
 // image
 // key : Swarm batchID (batch of stamps)
-const nftSwarmImageUri = async (image: string | File, key = ""): Promise<string> => {
+const nftSwarmImageUri = async (
+  image: string | File,
+  storageOption: StorageOptionType = { default: "swarm" }
+): Promise<string> => {
   let file: string | File = image;
 
   if (typeof image === "string" && (image.startsWith("http") || image.startsWith("data:"))) {
@@ -27,7 +30,7 @@ const nftSwarmImageUri = async (image: string | File, key = ""): Promise<string>
     file = image;
   }
 
-  const swarmImageUri = `swarm://${await swarmUploadFile(file, key)}`;
+  const swarmImageUri = `swarm://${await swarmUploadFile(file, storageOption)}`;
 
   return swarmImageUri;
 };
@@ -41,7 +44,8 @@ const nftSwarmTokenUri = async (
   image = "",
   metadata = "{}",
   properties: Properties = {},
-  animation_url = ""
+  animation_url = "",
+  storageOption: StorageOptionType = { default: "swarm" }
 ): Promise<string> => {
   const json = {
     name,
@@ -55,7 +59,7 @@ const nftSwarmTokenUri = async (
   if (Object.keys(properties).length > 0) json.properties = properties;
   if (animation_url) json.animation_url = ipfsGatewayUrl(animation_url);
 
-  const swarmTokenUri = `swarm://${await swarmUploadFile(JSON.stringify(json, null, 2))}`;
+  const swarmTokenUri = `swarm://${await swarmUploadFile(JSON.stringify(json, null, 2), storageOption)}`;
 
   return swarmTokenUri;
 };

--- a/svelte/components/Main/MintButtonWp.svelte
+++ b/svelte/components/Main/MintButtonWp.svelte
@@ -5,7 +5,7 @@
   import { metamaskChainId, metamaskSignerAddress } from "@stores/metamask";
   import NftMintPopup from "../Nft/NftMintPopup.svelte";
   import { getDappUrl, ipfsLinkToCid } from "@lib/common/config";
-  import { NftType } from "@lib/common/types";
+  import { NftType, StorageOptionType } from "@lib/common/types";
   import { nftStorageSet } from "@lib/nft/storage/nft-uri";
 
   ////////////////////////////////////////////////////////////////
@@ -17,7 +17,7 @@
   export let alt: string = undefined;
   export let pid: string = undefined;
   export let nid: string = undefined;
-  export let storage: string = "";
+
   /////////////////////////////////////////////////
 
   let open = false;
@@ -45,9 +45,6 @@
   };
 
   onMount(async () => {
-    // SET storage type IPFS / Swarm or ArWeave
-    if (storage) nftStorageSet(storage);
-
     await metamaskInit();
   });
 </script>

--- a/wordpress/kredeum-nfts.handlebars.php
+++ b/wordpress/kredeum-nfts.handlebars.php
@@ -77,12 +77,12 @@ if ( is_admin() ) {
 
 // IPFS.
 define( 'IPFS_GATEWAY', '{{storage.ipfs.gateway}}' );
-define( 'NFT_STORAGE_KEY', get_option( '_KRE_NFT_STORAGE_KEY', '' ) ? get_option( '_KRE_NFT_STORAGE_KEY', '' ) : '{{storage.ipfs.nftStorageKey}}' );
+define( 'NFT_STORAGE_KEY', get_option( '_KRE_IPFS_STORAGE_KEY', '' ) ? get_option( '_KRE_IPFS_STORAGE_KEY', '' ) : '{{storage.ipfs.nftStorageKey}}' );
 
 // SWARM.
 define( 'SWARM_GATEWAY', '{{storage.swarm.gateway}}' );
-define( 'SWARM_NODE_URL', get_option( '_KRE_SWARM_NODE_URL', '' ) ? get_option( '_KRE_SWARM_NODE_URL', '' ) : str_replace( '/bzz', '', SWARM_GATEWAY ) );
-define( 'SWARM_BATCH_ID', get_option( '_KRE_SWARM_BATCH_ID', '' ) ? get_option( '_KRE_SWARM_BATCH_ID', '' ) : '0000000000000000000000000000000000000000000000000000000000000000' );
+define( 'SWARM_ENDPOINT', get_option( '_KRE_SWARM_ENDPOINT', '' ) ? get_option( '_KRE_SWARM_ENDPOINT', '' ) : str_replace( '/bzz', '', SWARM_GATEWAY ) );
+define( 'SWARM_BATCH_ID', get_option( '_KRE_SWARM_STORAGE_KEY', '' ) ? get_option( '_KRE_SWARM_STORAGE_KEY', '' ) : '0000000000000000000000000000000000000000000000000000000000000000' );
 
 require_once KREDEUM_NFTS_PLUGIN_PATH . 'common/storage/uri.php';
 require_once KREDEUM_NFTS_PLUGIN_PATH . 'common/storage/link.php';

--- a/wordpress/plugins/kredeum-nfts/admin/media-list/column.php
+++ b/wordpress/plugins/kredeum-nfts/admin/media-list/column.php
@@ -48,7 +48,7 @@ add_action(
 				. ' nid="' . esc_attr( $nid ) . '"'
 				. ' metadata="' . esc_attr( wp_json_encode( $metadata ) ) . '"'
 				. ' alt="' . esc_attr( $post->post_title ) . '"'
-				. ' storage="' . ( defined( 'STORAGE_CHOICE' ) ? esc_attr( STORAGE_CHOICE ) : '' ) . '"/>'
+				. '/>'
 			);
 		}
 	}

--- a/wordpress/plugins/kredeum-nfts/admin/settings/fields.php
+++ b/wordpress/plugins/kredeum-nfts/admin/settings/fields.php
@@ -44,7 +44,7 @@ function fields() {
 		),
 
 		array(
-			'uid'         => '_kre_nft_storage_key',
+			'uid'         => '_kre_ipfs_storage_key',
 			'label'       => 'NFT_STORAGE_KEY',
 			'section'     => 'first_section',
 			'type'        => 'textarea',
@@ -55,8 +55,8 @@ function fields() {
 		),
 
 		array(
-			'uid'         => '_kre_swarm_node_url',
-			'label'       => 'SWARM_NODE_URL',
+			'uid'         => '_kre_swarm_endpoint',
+			'label'       => 'SWARM_ENDPOINT',
 			'section'     => 'first_section',
 			'type'        => 'text',
 			'placeholder' => 'Your Swarm Bee node URL',
@@ -65,7 +65,7 @@ function fields() {
 			'class'       => 'kre-swarm-storage kre-storage-option',
 		),
 		array(
-			'uid'         => '_kre_swarm_batch_id',
+			'uid'         => '_kre_swarm_storage_key',
 			'label'       => 'SWARM_BATCH_ID',
 			'section'     => 'first_section',
 			'type'        => 'text',

--- a/wordpress/plugins/kredeum-nfts/admin/settings/storage-choice.js
+++ b/wordpress/plugins/kredeum-nfts/admin/settings/storage-choice.js
@@ -14,4 +14,31 @@ window.onload = (e) => {
         });
         displayOption(event.target.value);
     });
+    
+    // Storage options on localstorage
+    let settingsForm = document.querySelector(".nfts_page_storage_settings form");
+    // console.log("settingsForm:", settingsForm)
+    
+    settingsForm.addEventListener('submit', (event) => {
+       let storageChoice = document.querySelector('#_kre_storage_choice').value;
+    //    console.log("settingdForm.addEventListener ~ storageChoice:", storageChoice);
+       let storageEndpoint = document.querySelector(`#_kre_${storageChoice}_endpoint`)?.value || "";
+    //    console.log("settingdForm.addEventListener ~ storageEndpoint:", storageEndpoint);
+       let storageKey = document.querySelector(`#_kre_${storageChoice}_storage_key`)?.value || "";
+    //    console.log("//settingdForm.addEventListener ~ storageKey:", storageKey)
+       
+       const storageOptions = {
+        default: storageChoice,
+       }
+       storageOptions[storageChoice] = {
+        apiEndpoint: storageEndpoint,
+        apiKey: storageKey
+      };
+      
+      if (typeof localStorage !== "undefined") {
+        const storage = JSON.stringify(storageOptions);
+        localStorage.setItem("storage", storage);
+      }
+       
+    });
 }

--- a/wordpress/plugins/kredeum-nfts/admin/storage/query.php
+++ b/wordpress/plugins/kredeum-nfts/admin/storage/query.php
@@ -38,7 +38,7 @@ function insert( $post_id ) {
 				}
 				break;
 			case 'swarm':
-				if ( defined( 'SWARM_NODE_URL' ) && defined( 'SWARM_BATCH_ID' ) ) {
+				if ( defined( 'SWARM_ENDPOINT' ) && defined( 'SWARM_BATCH_ID' ) ) {
 					$uri = 'swarm://' . swarm_add_and_pin( $post_id );
 				}
 				break;

--- a/wordpress/plugins/kredeum-nfts/admin/storage/swarm/swarm-bee.php
+++ b/wordpress/plugins/kredeum-nfts/admin/storage/swarm/swarm-bee.php
@@ -15,14 +15,14 @@ namespace KredeumNFTs\Storage;
  * @return string URI hash
  */
 function swarm_add_and_pin( $attachment_id ) {
-	if ( defined( 'SWARM_NODE_URL' ) && defined( 'SWARM_BATCH_ID' ) ) {
+	if ( defined( 'SWARM_ENDPOINT' ) && defined( 'SWARM_BATCH_ID' ) ) {
 		$swarm_pin = false;
 
 		if ( SWARM_BATCH_ID !== '0000000000000000000000000000000000000000000000000000000000000000' ) {
 			$swarm_pin = true;
 		}
 
-		$swarm_api = new \RestClient( array( 'base_url' => SWARM_NODE_URL ) );
+		$swarm_api = new \RestClient( array( 'base_url' => SWARM_ENDPOINT ) );
 
 		$file         = file_get_contents( get_attached_file( $attachment_id ) );
 		$filename     = get_attached_file_meta( $attachment_id )->filename;
@@ -38,7 +38,7 @@ function swarm_add_and_pin( $attachment_id ) {
 	}
 
 	// var_dump($result->decode_response()->reference);
-	// var_dump(SWARM_NODE_URL);
+	// var_dump(SWARM_ENDPOINT);
 	// var_dump($result->info->http_code);
 	// die();
 	// .


### PR DESCRIPTION
Add admin nftStorageKey for IPFS or nodeUrl & batchID for Swarm in local storage to use it on storage upload on minting in wordpress média.

localStorage is setted in Kredeum Nfts wordpress settings (default ipfs)

Have to add in .env :
```
SWARM_END_POINT = "https://api.gateway.ethswarm.org"
GATEWAY_SWARM_BATCH_ID = "0000000000000000000000000000000000000000000000000000000000000000"
```

Tested with NGrok with external url