### PR TITLE
get abis from Map collection.supports

### DIFF
--- a/common/lib/collection/collection-get.ts
+++ b/common/lib/collection/collection-get.ts
@@ -33,16 +33,20 @@ const collectionGetContract = async (
   if (!contract) {
     let abi: Array<JsonFragment> = [];
 
-    for (const [key, support] of Object.entries(collection.supports || {})) {
-      if (support) {
-        const abiKey = getAbi(key) as JsonFragment;
+    console.log("collection.supports:", collection.supports);
+    if (collection.supports?.entries()) {
+      for (const [key, support] of collection.supports.entries()) {
+        if (support) {
+          const abiKey = getAbi(key) as JsonFragment;
+          console.log("abiKey:", abiKey);
 
-        if (abiKey) {
-          const keyAbi = key == "IOpenNFTsV3" ? "IOpenNFTsV3Plus" : key;
-          // console.log("collectionGetContract", key, abiKey);
-          abi = abi.concat(getAbi(keyAbi) as JsonFragment);
-        } else {
-          console.error("collectionGetContract ERROR", key);
+          if (abiKey) {
+            const keyAbi = key == "IOpenNFTsV3" ? "IOpenNFTsV3Plus" : key;
+            // console.log("collectionGetContract", key, abiKey);
+            abi = abi.concat(getAbi(keyAbi) as JsonFragment);
+          } else {
+            console.error("collectionGetContract ERROR", key);
+          }
         }
       }
     }


### PR DESCRIPTION
### Mint NFT error
Tests to get supports from Map collection.supports entries to create ABIs
This permit to mint NFT without this error :
"Uncaught (in promise) TypeError: l.mint(address,string,uint256,address,uint96) is not a function"
![image](https://github.com/Kredeum/kredeum/assets/35979307/5ca77f33-6123-467c-8e08-9c9875606278)

### Mint collection bug
Still can't mint a collection.
It works in the UI (Tx signature, success) but the collection doesn't appear in collection selector in UI.
(contract seems to be cloned, but the contract is not verified... perhaps a address error for the original contract cloned ?)